### PR TITLE
Cocoapods v1 で pod install がエラーとなっていたため、Podfile にターゲット指定を追加。

### DIFF
--- a/examples/chapter04/04-01_PictureSharingApp/iOS/picture-sharing-app-for-ios/Podfile
+++ b/examples/chapter04/04-01_PictureSharingApp/iOS/picture-sharing-app-for-ios/Podfile
@@ -1,9 +1,11 @@
 platform :ios, '8.0'
 use_frameworks!
 
-pod 'AWSCore'
-pod 'AWSCognito'
-pod 'AWSS3'
-pod 'AWSSNS'
-pod 'FBSDKCoreKit'
-pod 'FBSDKLoginKit'
+target 'PictureSharingApp' do
+    pod 'AWSCore'
+    pod 'AWSCognito'
+    pod 'AWSS3'
+    pod 'AWSSNS'
+    pod 'FBSDKCoreKit'
+    pod 'FBSDKLoginKit'
+end

--- a/examples/chapter04/04-06_AttendanceManagementApp/iOS/attendance-management-app-for-ios/Podfile
+++ b/examples/chapter04/04-06_AttendanceManagementApp/iOS/attendance-management-app-for-ios/Podfile
@@ -1,7 +1,8 @@
 platform :ios, '8.0'
 use_frameworks!
 
-pod 'AWSCore'
-pod 'AWSCognito'
-pod 'AWSAPIGateway'
-
+target 'AttendanceManagementApp' do
+    pod 'AWSCore'
+    pod 'AWSCognito'
+    pod 'AWSAPIGateway'
+end

--- a/examples/chapter04/04-11_CognitoSyncMemoApp/iOS/cognito-sync-memo-app-for-ios/Podfile
+++ b/examples/chapter04/04-11_CognitoSyncMemoApp/iOS/cognito-sync-memo-app-for-ios/Podfile
@@ -1,7 +1,9 @@
 platform :ios, '8.0'
 use_frameworks!
 
-pod 'AWSCore'
-pod 'AWSCognito'
-pod 'FBSDKCoreKit'
-pod 'FBSDKLoginKit'
+target 'CognitoSyncMemoApp' do
+    pod 'AWSCore'
+    pod 'AWSCognito'
+    pod 'FBSDKCoreKit'
+    pod 'FBSDKLoginKit'
+end


### PR DESCRIPTION
Cocoapods v1 以降で `pod install` するとエラーが表示されるといった現象が発生していた。
原因は `Podfile` でターゲットを指定していなかったため。Cocoapods v1 以降で指定必須となったとのこと。

本コミットにて `Podfile` にターゲット指定を追加し、エラーを解消した。

参考文献
- [ios - Pod install displaying error in cocoapods version 1.0.0.beta.1 - Stack Overflow](http://stackoverflow.com/questions/34556991/pod-install-displaying-error-in-cocoapods-version-1-0-0-beta-1)
- [Cocoapods 1.0.0で注意すること - Qiita](http://qiita.com/ShinokiRyosei/items/7187ffb71862aba7e240)
